### PR TITLE
Add OpenClaw Monitor to Agent Observability

### DIFF
--- a/data/tools.yml
+++ b/data/tools.yml
@@ -9945,3 +9945,30 @@
   sources:
     - https://zenity.io
     - https://zenity.io/platform/ai-observability
+- slug: openclaw-monitor
+  name: OpenClaw Monitor
+  description: Real-time monitoring dashboard for OpenClaw agents — track task execution, token usage, and agent activity with an intuitive UI.
+  website_url: https://github.com/flik2002/openclaw-monitor
+  repo_url: https://github.com/flik2002/openclaw-monitor
+  docs_url: https://github.com/flik2002/openclaw-monitor
+  categories:
+    - agent-observability
+  tags:
+    - agents
+    - cost-tracking
+    - debugging
+    - local-first
+    - monitoring
+    - observability
+    - open-source
+    - openclaw
+  interfaces:
+    - web-ui
+  deployment: self-hosted
+  source_model: open-source
+  license: MIT
+  curation_status: reviewed
+  added: 2026-05-18
+  last_checked: 2026-05-18
+  sources:
+    - https://github.com/flik2002/openclaw-monitor


### PR DESCRIPTION
## OpenClaw Monitor — Real-time AI Agent Monitoring Dashboard

Add [OpenClaw Monitor](https://github.com/flik2002/openclaw-monitor) to the Agent Observability section.

### Why

OpenClaw Monitor helps developers monitor their OpenClaw agents in real time:

- **Token usage tracking** — Monitor message counts and estimate token consumption across sessions
- **Session management** — View active sessions, message history, and agent status
- **Multi-channel support** — Monitor agents across different platforms (DingTalk, WeChat, Telegram)
- **7-day trend charts** — Visualize message volume and activity patterns
- **Self-hosted** — Full control, no external cloud required

### Entry Details

- **Category**: agent-observability
- **License**: MIT
- **Deployment**: Self-hosted
- **Source**: Open-source
- **Interface**: Web UI

### Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries