### PR TITLE
Add Ivy Tendril to coding-agents

### DIFF
--- a/data/tools.yml
+++ b/data/tools.yml
@@ -9972,3 +9972,27 @@
   sources:
     - https://zenity.io
     - https://zenity.io/platform/ai-observability
+- slug: ivy-tendril
+  name: Ivy Tendril
+  description: Open-source AI coding orchestrator that manages Claude Code, Codex, Antigravity, Copilot, and OpenCode through a plan-based lifecycle with verification gates and self-improving memory.
+  website_url: https://tendril.ivy.app
+  docs_url: https://tendril.ivy.app/getting-started/installation
+  categories:
+    - coding-agents
+  primary_category: coding-agents
+  tags:
+    - agent
+    - orchestration
+    - multi-agent
+    - verification
+    - worktree
+  interfaces:
+    - desktop
+  deployment: local
+  source_model: open-source
+  license: FSL-1.1-ALv2
+  curation_status: draft
+  added: 2026-05-28
+  last_checked: 2026-05-28
+  sources:
+    - https://github.com/Ivy-Interactive/Ivy-Tendril


### PR DESCRIPTION
Adds Ivy Tendril to the coding-agents category in `data/tools.yml`.

Ivy Tendril is an open-source AI coding orchestrator that manages Claude Code, Codex, Antigravity, Copilot, and OpenCode through a plan-based lifecycle with verification gates and self-improving memory. Local-first desktop app.

- GitHub: https://github.com/Ivy-Interactive/Ivy-Tendril
- Website: https://tendril.ivy.app
- License: FSL-1.1-ALv2 (source-available, converts to Apache 2.0 after 2 years)
- Interface: Desktop
- Deployment: Local