### PR TITLE
Add codex-profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">Window-shop coding agents, IDE assistants, MCP tooling, evals, observability, security, and self-hosted AI dev stacks.</p>
 
-<p align="center"><code>360 tools</code> <code>274 reviewed</code> <code>86 draft</code> <code>18 active reviewed shelves</code></p>
+<p align="center"><code>361 tools</code> <code>275 reviewed</code> <code>86 draft</code> <code>18 active reviewed shelves</code></p>
 
 ## Why this exists
 
@@ -70,7 +70,7 @@ No rankings. No launch hype. Just a clean storefront for discovering tools worth
 
 ### Build with agents
 
-[Coding agents](#coding-agents) (27) · [Terminal agents](#terminal-agents) (13) · [IDE assistants](#ide-assistants) (17) · [Browser agents](#browser-agents) (24)
+[Coding agents](#coding-agents) (27) · [Terminal agents](#terminal-agents) (14) · [IDE assistants](#ide-assistants) (17) · [Browser agents](#browser-agents) (24)
 
 ### Extend agents
 
@@ -90,7 +90,7 @@ No rankings. No launch hype. Just a clean storefront for discovering tools worth
 
 ## Comparison Matrix
 
-_Showing a curated top 50 tools. See [docs/COMPARISON.md](docs/COMPARISON.md) for the full matrix of all 274 reviewed tools._
+_Showing a curated top 50 tools. See [docs/COMPARISON.md](docs/COMPARISON.md) for the full matrix of all 275 reviewed tools._
 
 | Tool | Main shelf | OSS | Local | Self-hosted | CLI | IDE | MCP | Links |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -196,6 +196,7 @@ AI developer tools primarily operated from a command-line interface.
 | [Augment Code](https://www.augmentcode.com/) | Repo-aware coding agent for editors and terminal that edits files, uses tools, and understands large codebases. | CLI · IDE · Hybrid | [Website](https://www.augmentcode.com/) / [Docs](https://docs.augmentcode.com/introduction) |
 | [Claude Code](https://code.claude.com/docs/en/setup) | Anthropic coding agent for terminal workflows that can read code, edit files, run commands, and use project context. | CLI · Hybrid | [Docs](https://code.claude.com/docs/en/setup) |
 | [CodeRabbit](https://coderabbit.ai/) | AI code review agent for pull requests, local IDE review, and terminal-based review workflows. | CLI · GitHub app · IDE · Hybrid | [Website](https://coderabbit.ai/) / [Docs](https://docs.coderabbit.ai/) |
+| [codex-profiles](https://ducksss.github.io/codex-profiles/) | Bash CLI that launches Codex CLI or Desktop with isolated CODEX_HOME profiles for account and context switching. | CLI · Local | [Website](https://ducksss.github.io/codex-profiles/) / [Docs](https://github.com/Ducksss/codex-profiles#readme) / [Repo](https://github.com/Ducksss/codex-profiles) |
 | [Factory Droid](https://factory.ai/) | Coding agent platform with CLI, desktop, and headless automation for code changes, review, and CI workflows. | API · CLI · Desktop · Hybrid | [Website](https://factory.ai/) / [Docs](https://docs.factory.ai/welcome) |
 | [Gemini CLI](https://developers.google.com/gemini-code-assist/docs/gemini-cli) | Open-source terminal coding agent that uses tool calls and MCP servers to work on repository tasks. | CLI · MCP · Local | [Docs](https://developers.google.com/gemini-code-assist/docs/gemini-cli) / [Repo](https://github.com/google-gemini/gemini-cli) |
 | [Junie](https://www.jetbrains.com/junie/) | JetBrains coding agent for IDEs and terminal that plans, edits, tests, and reviews project changes. | CLI · IDE · Hybrid | [Website](https://www.jetbrains.com/junie/) / [Docs](https://www.jetbrains.com/help/ai-assistant/junie-agent.html) / [Repo](https://github.com/JetBrains/junie) |
@@ -614,6 +615,7 @@ Directories, curated lists, and registries of AI developer tools and resources.
 
 ## New Arrivals
 
+- 2026-06-11: [codex-profiles](https://ducksss.github.io/codex-profiles/)
 - 2026-05-28: [Ivy Tendril](https://tendril.ivy.app)
 - 2026-05-28: [Komos](https://www.komos.ai/browser-automation-tools)
 - 2026-05-18: [OpenClaw Monitor](https://github.com/flik2002/openclaw-monitor)
@@ -621,7 +623,6 @@ Directories, curated lists, and registries of AI developer tools and resources.
 - 2026-05-15: [Guardrails AI](https://github.com/ShreyaR/guardrails)
 - 2026-05-15: [Haystack](https://github.com/deepset-ai/haystack)
 - 2026-05-15: [LiteLLM Gateway](https://github.com/BerriAI/litellm)
-- 2026-05-15: [PydanticAI](https://github.com/pydantic/pydantic-ai)
 
 ## Needs review
 

--- a/data/tools.yml
+++ b/data/tools.yml
@@ -2186,6 +2186,32 @@
   last_checked: 2026-05-15
   sources:
     - https://github.com/codex-src/codex-docs
+- slug: codex-profile
+  name: codex-profiles
+  description: Bash CLI that launches Codex CLI or Desktop with isolated CODEX_HOME profiles for account and context switching.
+  website_url: https://ducksss.github.io/codex-profiles/
+  repo_url: https://github.com/Ducksss/codex-profiles
+  docs_url: https://github.com/Ducksss/codex-profiles#readme
+  categories:
+    - terminal-agents
+  tags:
+    - cli
+    - developer-experience
+    - local-first
+    - open-source
+    - terminal
+  interfaces:
+    - cli
+  deployment: local
+  source_model: open-source
+  license: MIT
+  curation_status: reviewed
+  added: 2026-06-11
+  last_checked: 2026-06-11
+  sources:
+    - https://ducksss.github.io/codex-profiles/
+    - https://github.com/Ducksss/codex-profiles
+    - https://www.npmjs.com/package/codex-profile
 - slug: codium-ai-testgen
   name: CodiumAI TestGen
   description: Extension and CLI that generates unit tests from code and docstrings for multiple languages using AI.

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -2,7 +2,7 @@
 
 # Full Comparison Matrix
 
-This is the complete comparison matrix for all 274 reviewed tools.
+This is the complete comparison matrix for all 275 reviewed tools.
 
 | Tool | Main shelf | OSS | Local | Self-hosted | CLI | IDE | MCP | Links |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -67,6 +67,7 @@ This is the complete comparison matrix for all 274 reviewed tools.
 | [Cline](https://docs.cline.bot/introduction/overview) | Coding agents | Yes | No | No | Yes | Yes | Yes | [Docs](https://docs.cline.bot/introduction/overview) / [Repo](https://github.com/cline/cline) |
 | [Code2Docs](https://github.com/code2docs-ai) | Documentation agents | Yes | No | No | Yes | No | No | [Docs](https://github.com/code2docs-ai) / [Repo](https://github.com/xKarinSan/Code2Docs) |
 | [CodeRabbit](https://coderabbit.ai/) | AI code review tools | No | No | No | Yes | Yes | No | [Website](https://coderabbit.ai/) / [Docs](https://docs.coderabbit.ai/) |
+| [codex-profiles](https://ducksss.github.io/codex-profiles/) | Terminal agents | Yes | Yes | No | Yes | No | No | [Website](https://ducksss.github.io/codex-profiles/) / [Docs](https://github.com/Ducksss/codex-profiles#readme) / [Repo](https://github.com/Ducksss/codex-profiles) |
 | [Comet Opik](https://www.comet.com) | Agent observability | Yes | No | No | No | No | No | [Website](https://www.comet.com) / [Docs](https://docs.comet.com/docs/opik-overview) / [Repo](https://github.com/comet-ml/opik) |
 | [Confident AI](https://www.confident-ai.com) | Agent observability | No | No | No | No | No | No | [Website](https://www.confident-ai.com) / [Docs](https://www.confident-ai.com/docs) |
 | [Context7 MCP Server](https://context7.com) | MCP servers | Yes | No | No | No | No | Yes | [Website](https://context7.com) / [Repo](https://github.com/upstash/context7) |


### PR DESCRIPTION
## Summary

- Add codex-profiles as a reviewed Terminal agents entry.
- Regenerate README and full comparison matrix output.

## Data Sources

- [x] Official sources used for new or changed tool metadata.
- [x] Uncertain metadata marked as `not specified`.
- [x] Descriptions are factual and neutral.

## Checks

- [x] `npm run sort`
- [x] `npm run generate`
- [x] `npm test`

Notes:
- `npm test` passed locally.
- Validation reported existing unrelated source-host warnings for `ivy-tendril` and `ruflo`; no warnings were added for `codex-profile`.

Closes #8.