### PR TITLE
Add BrowserAct to browser agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">Window-shop coding agents, IDE assistants, MCP tooling, evals, observability, security, and self-hosted AI dev stacks.</p>
 
-<p align="center"><code>364 tools</code> <code>277 reviewed</code> <code>87 draft</code> <code>18 active reviewed shelves</code></p>
+<p align="center"><code>365 tools</code> <code>277 reviewed</code> <code>88 draft</code> <code>18 active reviewed shelves</code></p>
 
 ## Why this exists
 
@@ -650,13 +650,13 @@ Draft entries stay out of the main shelves until their metadata and sources are 
 | [Automatic Pull Request Review](https://github.com/marketplace/actions/automatic-pull-request-review) | Repo automation tools | Draft: source_model=not specified. | [Docs](https://github.com/marketplace/actions/automatic-pull-request-review) |
 | [Autopilot](https://github.com/princeton-nlp/Autopilot) | Coding agents | Draft: confirm stability and supported providers. | [Docs](https://github.com/princeton-nlp/Autopilot#readme) / [Repo](https://github.com/princeton-nlp/Autopilot) |
 | [Awesome Codex Skills](https://github.com/ComposioHQ/awesome-codex-skills) | Registries and curated lists | Draft: source_model=not specified. | [Repo](https://github.com/ComposioHQ/awesome-codex-skills) |
+| [BrowserAct](https://www.browseract.com) | Browser agents | Draft: verify the current deployment model and product scope. | [Website](https://www.browseract.com) / [Docs](https://github.com/browser-act/skills/tree/main/docs) / [Repo](https://github.com/browser-act/skills) |
 | [ChatGPT Retrieval Plugin](https://github.com/openai/chatgpt-retrieval-plugin) | Local LLM developer tools | Draft: historical but still a reference retrieval implementation. | [Docs](https://github.com/openai/chatgpt-retrieval-plugin#readme) / [Repo](https://github.com/openai/chatgpt-retrieval-plugin) |
 | [ci-debug-action](https://github.com/alpacahq/ci-debug-action) | Repo automation tools | Draft: source_model=not specified. | [Repo](https://github.com/alpacahq/ci-debug-action) |
 | [Cline Prompts](https://github.com/cline/prompts) | Agent skill packs | Draft: source_model=not specified. | [Repo](https://github.com/cline/prompts) |
 | [Code Summarizer Action](https://github.com/marketplace/actions/code-summarizer) | Repo automation tools | Draft: verify current marketplace listing and name. | [Website](https://github.com/marketplace/actions/code-summarizer) / [Docs](https://github.com/kubescape/code-summarizer#readme) / [Repo](https://github.com/kubescape/code-summarizer) |
-| [Codebrush](https://github.com/tldraw/codebrush) | Data and ML coding assistants | Draft: narrow language focus but good DX tool. | [Docs](https://github.com/tldraw/codebrush#readme) / [Repo](https://github.com/tldraw/codebrush) |
 
-_Showing 20 of 87 draft entries. Full queue in `data/tools.yml`._
+_Showing 20 of 88 draft entries. Full queue in `data/tools.yml`._
 
 ## Submit a tool
 
@@ -672,7 +672,7 @@ Use official sources, keep descriptions factual, and leave uncertain metadata as
 
 ## Roadmap
 
-- Review and promote 87 queued draft entries, prioritising thin shelves.
+- Review and promote 88 queued draft entries, prioritising thin shelves.
 - Expand thin reviewed shelves: Data and ML coding assistants (1 reviewed), Registries and curated lists (5 reviewed), MCP clients (6 reviewed).
 - Populate empty shelves when quality entries are found: Prompt and workflow libraries, AI devtools security, DevOps and SRE agents.
 - Act on the weekly maintenance reports: fix confirmed-broken links and re-verify stale entries.

--- a/data/tools.yml
+++ b/data/tools.yml
@@ -1619,6 +1619,35 @@
     - https://browser-use.com
     - https://dzone.com/articles/build-ai-browser-agent-llms-playwright-browser-use
     - https://github.com/browser-use/browser-use
+- slug: browser-act
+  name: BrowserAct
+  description: Browser automation CLI for AI agents with local Chrome reuse, isolated sessions, optional managed browsers, and human handoff.
+  website_url: https://www.browseract.com
+  repo_url: https://github.com/browser-act/skills
+  docs_url: https://github.com/browser-act/skills/tree/main/docs
+  categories:
+    - browser-agents
+  tags:
+    - agent-skills
+    - automation
+    - browser-agents
+    - browser-automation
+    - cli
+    - open-source
+    - web-automation
+  interfaces:
+    - cli
+  deployment: hybrid
+  source_model: open-source
+  license: MIT
+  curation_status: draft
+  review_notes: "Draft: verify the current deployment model and product scope."
+  added: 2026-07-15
+  last_checked: 2026-07-15
+  sources:
+    - https://github.com/browser-act/skills
+    - https://github.com/browser-act/skills/tree/main/docs
+    - https://www.browseract.com
 - slug: browserbase
   name: Browserbase
   description: Cloud headless browser infrastructure built for AI agents and web automation, providing scalable browser sessions with anti-detection features.


### PR DESCRIPTION
## Summary\n\n- Add BrowserAct as a draft entry in the Browser agents category.\n- Use official website, repository, and documentation sources.\n- Regenerate the README from the structured YAML source.\n\nBrowserAct is a browser automation CLI for AI agents with local Chrome reuse, isolated sessions, optional managed browsers, and human handoff.\n\n## Validation\n\n- TypeScript typecheck passed\n- 59 unit tests passed\n- Catalog validation passed