### PR TITLE
Add whatbroke to agent evals

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">Window-shop coding agents, IDE assistants, MCP tooling, evals, observability, security, and self-hosted AI dev stacks.</p>
 
-<p align="center"><code>367 tools</code> <code>279 reviewed</code> <code>88 draft</code> <code>18 active reviewed shelves</code></p>
+<p align="center"><code>368 tools</code> <code>280 reviewed</code> <code>88 draft</code> <code>18 active reviewed shelves</code></p>
 
 ## Why this exists
 
@@ -78,7 +78,7 @@ No rankings. No launch hype. Just a clean storefront for discovering tools worth
 
 ### Operate agents
 
-[Agent observability](#agent-observability) (43) · [Agent evals](#agent-evals) (22)
+[Agent observability](#agent-observability) (43) · [Agent evals](#agent-evals) (23)
 
 ### Run locally/self-host
 
@@ -90,7 +90,7 @@ No rankings. No launch hype. Just a clean storefront for discovering tools worth
 
 ## Comparison Matrix
 
-_Showing a curated top 50 tools. See [docs/COMPARISON.md](docs/COMPARISON.md) for the full matrix of all 279 reviewed tools._
+_Showing a curated top 50 tools. See [docs/COMPARISON.md](docs/COMPARISON.md) for the full matrix of all 280 reviewed tools._
 
 | Tool | Main shelf | OSS | Local | Self-hosted | CLI | IDE | MCP | Links |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -435,6 +435,7 @@ Evaluation frameworks and systems for agents, LLM apps, and developer workflows.
 | [Rhesis AI](https://www.rhesis.ai) | Open-source collaborative testing platform for LLM and agentic applications with UI, SDK, and CI integration. | API · CLI · Framework · Web | [Website](https://www.rhesis.ai) / [Docs](https://docs.rhesis.ai) / [Repo](https://github.com/rhesis-ai/rhesis) |
 | [Unitxt](https://www.unitxt.ai) | IBM-backed library and catalog for textual data preparation and evaluation of generative language models across many tasks. | CLI · Framework · Library | [Website](https://www.unitxt.ai) / [Docs](https://www.unitxt.ai/en/main/docs/introduction.html) / [Repo](https://github.com/ibm/unitxt) |
 | [Vectara Open Evaluation UI](https://www.vectara.com/blog/open-evaluation) | Web UI for loading reports from Open RAG Eval and comparing RAG configurations across queries and metrics. | Framework · Web | [Website](https://www.vectara.com/blog/open-evaluation) / [Docs](https://docs.vectara.com/docs/hallucination-and-evaluation/open-eval-framework) |
+| [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) | CLI that diffs an AI agent's behavior between two runs, comparing tool calls, args, cost, latency, and outcome flips. | CLI · Local | [Repo](https://github.com/arthi-arumugam-git/whatbroke) |
 
 ### Self-hosted AI dev stacks
 
@@ -623,6 +624,7 @@ Directories, curated lists, and registries of AI developer tools and resources.
 
 ## New Arrivals
 
+- 2026-07-24: [whatbroke](https://github.com/arthi-arumugam-git/whatbroke)
 - 2026-07-22: [UIZZE](https://uizze.com)
 - 2026-07-16: [Agent Island](https://agent-island.dev)
 - 2026-07-07: [Tree Ring Memory](https://terminallylazy.github.io/Tree-Ring-Memory/)
@@ -630,7 +632,6 @@ Directories, curated lists, and registries of AI developer tools and resources.
 - 2026-06-11: [codex-profiles](https://ducksss.github.io/codex-profiles/)
 - 2026-05-28: [Ivy Tendril](https://tendril.ivy.app)
 - 2026-05-28: [Komos](https://www.komos.ai/browser-automation-tools)
-- 2026-05-18: [OpenClaw Monitor](https://github.com/flik2002/openclaw-monitor)
 
 ## Needs review
 

--- a/data/tools.yml
+++ b/data/tools.yml
@@ -10002,6 +10002,32 @@
     - https://venturebeat.com/ai/weights-biases-new-llmops-capabilities-ai-development-model-monitoring
     - https://wandb.ai
     - https://wandb.ai/onlineinference/genai-research/reports/A-guide-to-LLM-debugging-tracing-and-monitoring--VmlldzoxMzk1MjAyOQ
+- slug: whatbroke
+  name: whatbroke
+  description: CLI that diffs an AI agent's behavior between two runs, comparing tool calls, args, cost, latency, and outcome flips.
+  website_url: https://github.com/arthi-arumugam-git/whatbroke
+  repo_url: https://github.com/arthi-arumugam-git/whatbroke
+  categories:
+    - agent-evals
+  tags:
+    - agent-evals
+    - cli
+    - debugging
+    - evals
+    - open-source
+    - regression-testing
+    - testing
+  interfaces:
+    - cli
+  deployment: local
+  source_model: open-source
+  license: MIT
+  curation_status: reviewed
+  added: 2026-07-24
+  last_checked: 2026-07-24
+  sources:
+    - https://github.com/arthi-arumugam-git/whatbroke
+    - https://www.npmjs.com/package/whatbroke-cli
 - slug: whylabs-openllmtelemetry
   name: WhyLabs OpenLLMTelemetry
   description: Python library that instruments LLM calls and sends OpenTelemetry traces and safeguards data to WhyLabs.

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -2,7 +2,7 @@
 
 # Full Comparison Matrix
 
-This is the complete comparison matrix for all 279 reviewed tools.
+This is the complete comparison matrix for all 280 reviewed tools.
 
 | Tool | Main shelf | OSS | Local | Self-hosted | CLI | IDE | MCP | Links |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -278,6 +278,7 @@ This is the complete comparison matrix for all 279 reviewed tools.
 | [WebMCP JavaScript Library](https://webmcp.dev) | MCP tooling | Yes | Yes | No | No | No | Yes | [Website](https://webmcp.dev) / [Docs](https://docs.mcp-b.ai/explanation/webmcp-vs-mcp) / [Repo](https://github.com/webmachinelearning/webmcp) |
 | [WebVoyager](https://github.com/MinorJerry/WebVoyager) | Browser agents | Yes | No | No | No | No | No | [Repo](https://github.com/MinorJerry/WebVoyager) |
 | [Weights & Biases Weave](https://wandb.ai) | Agent observability | Yes | No | No | No | No | No | [Website](https://wandb.ai) / [Docs](https://docs.wandb.ai/guides/weave) / [Repo](https://github.com/wandb/weave) |
+| [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) | Agent evals | Yes | Yes | No | Yes | No | No | [Repo](https://github.com/arthi-arumugam-git/whatbroke) |
 | [WhyLabs OpenLLMTelemetry](https://whylabs.ai) | Agent observability | Yes | Yes | No | No | No | No | [Website](https://whylabs.ai) / [Docs](https://docs.whylabs.ai/docs/openllmtelemetry) / [Repo](https://github.com/whylabs/openllmtelemetry) |
 | [Windsurf Editor](https://windsurf.com/) | IDE assistants | No | No | No | No | Yes | No | [Website](https://windsurf.com/) / [Docs](https://docs.windsurf.com/) |
 | [Winy RAG Sample Stack](https://github.com/mfranzon/winy) | Self-hosted AI dev stacks | Yes | No | Yes | No | No | No | [Docs](https://github.com/mfranzon/winy#readme) / [Repo](https://github.com/mfranzon/winy) |


### PR DESCRIPTION
Adds whatbroke, a CLI I built that diffs two agent runs and reports what changed: tool calls, order, args, cost, latency, and outcome flips, with flake detection across repeats. Entry added to data/tools.yml with official sources (repo and npm page), then ran npm run sort, npm run generate, and npm test locally. Validation passed, only pre-existing warnings. MIT, TypeScript, on npm as whatbroke-cli.