### PR TITLE
Add cursor-bridge: Claude Code on your Cursor subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">Window-shop coding agents, IDE assistants, MCP tooling, evals, observability, security, and self-hosted AI dev stacks.</p>
 
-<p align="center"><code>362 tools</code> <code>278 reviewed</code> <code>84 draft</code> <code>18 active reviewed shelves</code></p>
+<p align="center"><code>363 tools</code> <code>279 reviewed</code> <code>84 draft</code> <code>18 active reviewed shelves</code></p>
 
 ## Why this exists
 
@@ -70,7 +70,7 @@ No rankings. No launch hype. Just a clean storefront for discovering tools worth
 
 ### Build with agents
 
-[Coding agents](#coding-agents) (27) · [Terminal agents](#terminal-agents) (16) · [IDE assistants](#ide-assistants) (17) · [Browser agents](#browser-agents) (24)
+[Coding agents](#coding-agents) (28) · [Terminal agents](#terminal-agents) (16) · [IDE assistants](#ide-assistants) (17) · [Browser agents](#browser-agents) (24)
 
 ### Extend agents
 
@@ -90,7 +90,7 @@ No rankings. No launch hype. Just a clean storefront for discovering tools worth
 
 ## Comparison Matrix
 
-_Showing a curated top 50 tools. See [docs/COMPARISON.md](docs/COMPARISON.md) for the full matrix of all 278 reviewed tools._
+_Showing a curated top 50 tools. See [docs/COMPARISON.md](docs/COMPARISON.md) for the full matrix of all 279 reviewed tools._
 
 | Tool | Main shelf | OSS | Local | Self-hosted | CLI | IDE | MCP | Links |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -162,6 +162,7 @@ Agentic tools that can inspect, modify, and reason about source code.
 | [Claude Code](https://code.claude.com/docs/en/setup) | Anthropic coding agent for terminal workflows that can read code, edit files, run commands, and use project context. | CLI · Hybrid | [Docs](https://code.claude.com/docs/en/setup) |
 | [Cline](https://docs.cline.bot/introduction/overview) | Open-source coding agent for editor workflows with file edits, terminal commands, browser use, and MCP-based tool extension. | Browser · CLI · IDE · Hybrid | [Docs](https://docs.cline.bot/introduction/overview) / [Repo](https://github.com/cline/cline) |
 | [Cursor](https://cursor.com/) | AI code editor built around chat, codebase context, agents, rules, MCP, and terminal-assisted development workflows. | CLI · Desktop · IDE · Hybrid | [Website](https://cursor.com/) / [Docs](https://cursor.com/docs) |
+| [cursor-bridge](https://github.com/hkc5/cursor-bridge) | Rust proxy that routes Claude Code through Cursor's backend, using your Cursor subscription instead of Anthropic API. | CLI · Local | [Repo](https://github.com/hkc5/cursor-bridge) |
 | [Devin](https://devin.ai/) | Cloud software engineering agent for teams that works on repositories and can run tasks in parallel. | Web · Hosted | [Website](https://devin.ai/) / [Docs](https://docs.devin.ai/es/get-started/devin-intro) |
 | [Ellipsis](https://www.ellipsis.dev/) | GitHub agent that reviews pull requests, answers repo questions, and can generate changes or release notes. | GitHub app · Web · Hosted | [Website](https://www.ellipsis.dev/) / [Docs](https://docs.ellipsis.dev/introduction) |
 | [Factory Droid](https://factory.ai/) | Coding agent platform with CLI, desktop, and headless automation for code changes, review, and CI workflows. | API · CLI · Desktop · Hybrid | [Website](https://factory.ai/) / [Docs](https://docs.factory.ai/welcome) |
@@ -622,6 +623,7 @@ Directories, curated lists, and registries of AI developer tools and resources.
 
 ## New Arrivals
 
+- 2026-07-27: [cursor-bridge](https://github.com/hkc5/cursor-bridge)
 - 2026-07-24: [whatbroke](https://github.com/arthi-arumugam-git/whatbroke)
 - 2026-07-22: [UIZZE](https://uizze.com)
 - 2026-07-16: [Agent Island](https://agent-island.dev)
@@ -629,7 +631,6 @@ Directories, curated lists, and registries of AI developer tools and resources.
 - 2026-06-20: [ax](https://github.com/Necmttn/ax)
 - 2026-06-11: [codex-profiles](https://ducksss.github.io/codex-profiles/)
 - 2026-05-28: [Ivy Tendril](https://tendril.ivy.app)
-- 2026-05-28: [Komos](https://www.komos.ai/browser-automation-tools)
 
 ## Needs review
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ No rankings. No launch hype. Just a clean storefront for discovering tools worth
 
 - [Aider](https://aider.chat/) - Open-source terminal pair programmer that edits tracked files in a local Git repository.
 - [Cline](https://docs.cline.bot/introduction/overview) - Open-source coding agent for editor workflows with file edits, terminal commands, browser use, and MCP-based tool extension.
+- [cursor-bridge](https://github.com/hkc5/cursor-bridge) - Claude Code that runs on your Cursor subscription.
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for terminal, desktop, IDE, and GitHub repository workflows.
 - [OpenHands](https://openhands.dev/) - Open-source software agent platform with GUI, CLI, SDK, and self-hosted or cloud deployment options.
 - [Continue](https://docs.continue.dev/) - Open-source AI code assistant and CLI for IDE agents, source-controlled checks, and customizable development workflows.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ No rankings. No launch hype. Just a clean storefront for discovering tools worth
 
 - [Aider](https://aider.chat/) - Open-source terminal pair programmer that edits tracked files in a local Git repository.
 - [Cline](https://docs.cline.bot/introduction/overview) - Open-source coding agent for editor workflows with file edits, terminal commands, browser use, and MCP-based tool extension.
-- [cursor-bridge](https://github.com/hkc5/cursor-bridge) - Claude Code that runs on your Cursor subscription.
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for terminal, desktop, IDE, and GitHub repository workflows.
 - [OpenHands](https://openhands.dev/) - Open-source software agent platform with GUI, CLI, SDK, and self-hosted or cloud deployment options.
 - [Continue](https://docs.continue.dev/) - Open-source AI code assistant and CLI for IDE agents, source-controlled checks, and customizable development workflows.

--- a/data/tools.yml
+++ b/data/tools.yml
@@ -2472,6 +2472,30 @@
   last_checked: 2026-05-07
   sources:
     - https://github.com/survivorforge/cursor-rules
+- slug: cursor-bridge
+  name: cursor-bridge
+  description: Rust proxy that routes Claude Code through Cursor's backend, using your Cursor subscription instead of Anthropic API.
+  website_url: https://github.com/hkc5/cursor-bridge
+  repo_url: https://github.com/hkc5/cursor-bridge
+  categories:
+    - coding-agents
+  primary_category: coding-agents
+  tags:
+    - agentic-coding
+    - cli
+    - coding
+    - open-source
+    - proxy
+  interfaces:
+    - cli
+  deployment: local
+  source_model: open-source
+  license: MIT
+  curation_status: reviewed
+  added: 2026-07-27
+  last_checked: 2026-07-27
+  sources:
+    - https://github.com/hkc5/cursor-bridge
 - slug: cursorrules-collection
   name: Cursorrules Collection
   description: 110+ tested .cursorrules and .mdc rule files for Cursor, Claude Code, Copilot, Windsurf, Gemini CLI, and Codex.

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -2,7 +2,7 @@
 
 # Full Comparison Matrix
 
-This is the complete comparison matrix for all 278 reviewed tools.
+This is the complete comparison matrix for all 279 reviewed tools.
 
 | Tool | Main shelf | OSS | Local | Self-hosted | CLI | IDE | MCP | Links |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -75,6 +75,7 @@ This is the complete comparison matrix for all 278 reviewed tools.
 | [Continue](https://docs.continue.dev/) | IDE assistants | Yes | No | No | Yes | Yes | No | [Docs](https://docs.continue.dev/) / [Repo](https://github.com/continuedev/continue) |
 | [Cursor](https://cursor.com/) | IDE assistants | No | No | No | Yes | Yes | Yes | [Website](https://cursor.com/) / [Docs](https://cursor.com/docs) |
 | [Cursor Rules](https://github.com/survivorforge/cursor-rules) | Agent skill packs | Yes | Yes | No | No | No | No | [Repo](https://github.com/survivorforge/cursor-rules) |
+| [cursor-bridge](https://github.com/hkc5/cursor-bridge) | Coding agents | Yes | Yes | No | Yes | No | No | [Repo](https://github.com/hkc5/cursor-bridge) |
 | [Cursorrules Collection](https://github.com/nedcodes-ok/cursorrules-collection) | Agent skill packs | Yes | Yes | No | No | No | No | [Repo](https://github.com/nedcodes-ok/cursorrules-collection) |
 | [Custom Modes for Roo Code](https://github.com/jtgsystems/Custom-Modes-Roo-Code) | Agent skill packs | Yes | Yes | No | No | No | No | [Repo](https://github.com/jtgsystems/Custom-Modes-Roo-Code) |
 | [Datadog LLM Observability](https://www.datadoghq.com/product/ai/llm-observability/) | Agent observability | No | No | No | No | No | No | [Website](https://www.datadoghq.com/product/ai/llm-observability/) / [Docs](https://docs.datadoghq.com/tracing/llm_observability/) / [Repo](https://github.com/DataDog/llm-observability) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -537,29 +537,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/get-tsconfig": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
-      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
     "node_modules/spdx-exceptions": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",


### PR DESCRIPTION
cursor-bridge is a Rust binary that lets Claude Code run on Cursor's backend instead of Anthropic's API. If you already have a Cursor subscription, this makes Claude Code effectively free (Cursor's auto model is unlimited with subscription).

Features:
- Single Rust binary (~780KB), zero dependencies, zero config
- Tool execution (shell, file write, reads) works out of the box
- Agent runs in isolated temp dir — cannot touch your project files
- No daemon, no background process, no env vars to configure
- macOS + Linux

https://github.com/hkc5/cursor-bridge