### PR TITLE
Add Kolega Code to tools directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">Window-shop coding agents, IDE assistants, MCP tooling, evals, observability, security, and self-hosted AI dev stacks.</p>
 
-<p align="center"><code>366 tools</code> <code>281 reviewed</code> <code>85 draft</code> <code>18 active reviewed shelves</code></p>
+<p align="center"><code>366 tools</code> <code>282 reviewed</code> <code>84 draft</code> <code>18 active reviewed shelves</code></p>
 
 ## Why this exists
 
@@ -70,7 +70,7 @@ No rankings. No launch hype. Just a clean storefront for discovering tools worth
 
 ### Build with agents
 
-[Coding agents](#coding-agents) (29) · [Terminal agents](#terminal-agents) (17) · [IDE assistants](#ide-assistants) (17) · [Browser agents](#browser-agents) (25)
+[Coding agents](#coding-agents) (30) · [Terminal agents](#terminal-agents) (18) · [IDE assistants](#ide-assistants) (17) · [Browser agents](#browser-agents) (25)
 
 ### Extend agents
 
@@ -90,7 +90,7 @@ No rankings. No launch hype. Just a clean storefront for discovering tools worth
 
 ## Comparison Matrix
 
-_Showing a curated top 50 tools. See [docs/COMPARISON.md](docs/COMPARISON.md) for the full matrix of all 281 reviewed tools._
+_Showing a curated top 50 tools. See [docs/COMPARISON.md](docs/COMPARISON.md) for the full matrix of all 282 reviewed tools._
 
 | Tool | Main shelf | OSS | Local | Self-hosted | CLI | IDE | MCP | Links |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -173,6 +173,7 @@ Agentic tools that can inspect, modify, and reason about source code.
 | [Ivy Tendril](https://tendril.ivy.app) | Open-source AI coding orchestrator that manages Claude Code, Codex, Antigravity, Copilot and more through a plan-based lifecycle with verification gates and self-improving memory. | Desktop · Local | [Website](https://tendril.ivy.app) / [Docs](https://tendril.ivy.app/getting-started/installation) |
 | [Jules](https://jules.google/) | Google asynchronous coding agent for GitHub that fixes bugs, adds features, and updates documentation. | API · Web · Hosted | [Website](https://jules.google/) / [Docs](https://jules.google/docs/) |
 | [Junie](https://www.jetbrains.com/junie/) | JetBrains coding agent for IDEs and terminal that plans, edits, tests, and reviews project changes. | CLI · IDE · Hybrid | [Website](https://www.jetbrains.com/junie/) / [Docs](https://www.jetbrains.com/help/ai-assistant/junie-agent.html) / [Repo](https://github.com/JetBrains/junie) |
+| [Kolega Code](https://github.com/kolega-ai/kolega-code) | Open-source terminal coding agent where the model writes its own multi-agent workflows (Gigacode) for repo-wide tasks. | CLI · Local | [Docs](https://kolega-ai.github.io/kolega-code/) / [Repo](https://github.com/kolega-ai/kolega-code) |
 | [OpenAI Codex CLI](https://github.com/openai/codex) | Local terminal coding agent from OpenAI that can inspect code, edit files, and run commands in a developer workspace. | CLI · Hybrid | [Docs](https://developers.openai.com/codex/cli/) / [Repo](https://github.com/openai/codex) |
 | [OpenCode](https://opencode.ai/) | Open-source AI coding agent for terminal, desktop, IDE, and GitHub repository workflows. | CLI · Desktop · GitHub app · IDE · MCP · Local | [Website](https://opencode.ai/) / [Docs](https://opencode.ai/docs/) / [Repo](https://github.com/anomalyco/opencode) |
 | [OpenHands](https://openhands.dev/) | Open-source software agent platform with GUI, CLI, SDK, and self-hosted or cloud deployment options. | API · CLI · Web · Hybrid | [Website](https://openhands.dev/) / [Docs](https://docs.openhands.dev/overview/quickstart) / [Repo](https://github.com/OpenHands/OpenHands) |
@@ -204,6 +205,7 @@ AI developer tools primarily operated from a command-line interface.
 | [Factory Droid](https://factory.ai/) | Coding agent platform with CLI, desktop, and headless automation for code changes, review, and CI workflows. | API · CLI · Desktop · Hybrid | [Website](https://factory.ai/) / [Docs](https://docs.factory.ai/welcome) |
 | [Gemini CLI](https://developers.google.com/gemini-code-assist/docs/gemini-cli) | Open-source terminal coding agent that uses tool calls and MCP servers to work on repository tasks. | CLI · MCP · Local | [Docs](https://developers.google.com/gemini-code-assist/docs/gemini-cli) / [Repo](https://github.com/google-gemini/gemini-cli) |
 | [Junie](https://www.jetbrains.com/junie/) | JetBrains coding agent for IDEs and terminal that plans, edits, tests, and reviews project changes. | CLI · IDE · Hybrid | [Website](https://www.jetbrains.com/junie/) / [Docs](https://www.jetbrains.com/help/ai-assistant/junie-agent.html) / [Repo](https://github.com/JetBrains/junie) |
+| [Kolega Code](https://github.com/kolega-ai/kolega-code) | Open-source terminal coding agent where the model writes its own multi-agent workflows (Gigacode) for repo-wide tasks. | CLI · Local | [Docs](https://kolega-ai.github.io/kolega-code/) / [Repo](https://github.com/kolega-ai/kolega-code) |
 | [OpenAI Codex CLI](https://github.com/openai/codex) | Local terminal coding agent from OpenAI that can inspect code, edit files, and run commands in a developer workspace. | CLI · Hybrid | [Docs](https://developers.openai.com/codex/cli/) / [Repo](https://github.com/openai/codex) |
 | [OpenCode](https://opencode.ai/) | Open-source AI coding agent for terminal, desktop, IDE, and GitHub repository workflows. | CLI · Desktop · GitHub app · IDE · MCP · Local | [Website](https://opencode.ai/) / [Docs](https://opencode.ai/docs/) / [Repo](https://github.com/anomalyco/opencode) |
 | [Qwen Code](https://qwen.ai/) | Open-source terminal coding agent optimized for Qwen models and large repository tasks. | CLI · Local | [Website](https://qwen.ai/) / [Repo](https://github.com/QwenLM/qwen-code) |
@@ -630,6 +632,7 @@ Directories, curated lists, and registries of AI developer tools and resources.
 
 ## New Arrivals
 
+- 2026-08-17: [Kolega Code](https://github.com/kolega-ai/kolega-code)
 - 2026-08-16: [Agent QA](https://vostride.com/docs/agent-qa)
 - 2026-08-13: [Atomic Agent](https://atomicagent.io)
 - 2026-07-27: [cursor-bridge](https://github.com/hkc5/cursor-bridge)
@@ -637,7 +640,6 @@ Directories, curated lists, and registries of AI developer tools and resources.
 - 2026-07-22: [UIZZE](https://uizze.com)
 - 2026-07-16: [Agent Island](https://agent-island.dev)
 - 2026-07-07: [Tree Ring Memory](https://terminallylazy.github.io/Tree-Ring-Memory/)
-- 2026-06-20: [ax](https://github.com/Necmttn/ax)
 
 ## Needs review
 
@@ -666,7 +668,7 @@ Draft entries stay out of the main shelves until their metadata and sources are 
 | [Cline Prompts](https://github.com/cline/prompts) | Agent skill packs | Draft: source_model=not specified. | [Repo](https://github.com/cline/prompts) |
 | [Code Summarizer Action](https://github.com/marketplace/actions/code-summarizer) | Repo automation tools | Draft: verify current marketplace listing and name. | [Website](https://github.com/marketplace/actions/code-summarizer) / [Docs](https://github.com/kubescape/code-summarizer#readme) / [Repo](https://github.com/kubescape/code-summarizer) |
 
-_Showing 20 of 85 draft entries. Full queue in `data/tools.yml`._
+_Showing 20 of 84 draft entries. Full queue in `data/tools.yml`._
 
 ## Submit a tool
 
@@ -682,7 +684,7 @@ Use official sources, keep descriptions factual, and leave uncertain metadata as
 
 ## Roadmap
 
-- Review and promote 85 queued draft entries, prioritising thin shelves.
+- Review and promote 84 queued draft entries, prioritising thin shelves.
 - Expand thin reviewed shelves: Data and ML coding assistants (1 reviewed), Registries and curated lists (4 reviewed), MCP clients (7 reviewed).
 - Populate empty shelves when quality entries are found: Prompt and workflow libraries, AI devtools security, DevOps and SRE agents.
 - Act on the weekly maintenance reports: fix confirmed-broken links and re-verify stale entries.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">Window-shop coding agents, IDE assistants, MCP tooling, evals, observability, security, and self-hosted AI dev stacks.</p>
 
-<p align="center"><code>365 tools</code> <code>281 reviewed</code> <code>84 draft</code> <code>18 active reviewed shelves</code></p>
+<p align="center"><code>366 tools</code> <code>281 reviewed</code> <code>85 draft</code> <code>18 active reviewed shelves</code></p>
 
 ## Why this exists
 
@@ -666,7 +666,7 @@ Draft entries stay out of the main shelves until their metadata and sources are 
 | [Cline Prompts](https://github.com/cline/prompts) | Agent skill packs | Draft: source_model=not specified. | [Repo](https://github.com/cline/prompts) |
 | [Code Summarizer Action](https://github.com/marketplace/actions/code-summarizer) | Repo automation tools | Draft: verify current marketplace listing and name. | [Website](https://github.com/marketplace/actions/code-summarizer) / [Docs](https://github.com/kubescape/code-summarizer#readme) / [Repo](https://github.com/kubescape/code-summarizer) |
 
-_Showing 20 of 84 draft entries. Full queue in `data/tools.yml`._
+_Showing 20 of 85 draft entries. Full queue in `data/tools.yml`._
 
 ## Submit a tool
 
@@ -682,7 +682,7 @@ Use official sources, keep descriptions factual, and leave uncertain metadata as
 
 ## Roadmap
 
-- Review and promote 84 queued draft entries, prioritising thin shelves.
+- Review and promote 85 queued draft entries, prioritising thin shelves.
 - Expand thin reviewed shelves: Data and ML coding assistants (1 reviewed), Registries and curated lists (4 reviewed), MCP clients (7 reviewed).
 - Populate empty shelves when quality entries are found: Prompt and workflow libraries, AI devtools security, DevOps and SRE agents.
 - Act on the weekly maintenance reports: fix confirmed-broken links and re-verify stale entries.

--- a/data/tools.yml
+++ b/data/tools.yml
@@ -4753,6 +4753,34 @@
     - https://github.com/LostRuins/koboldcpp
     - https://github.com/LostRuins/koboldcpp/wiki
     - https://koboldcpp.com
+- slug: kolega-code
+  name: Kolega Code
+  description: Open-source terminal coding agent where the model writes its own multi-agent workflows (Gigacode) for repo-wide tasks.
+  website_url: https://github.com/kolega-ai/kolega-code
+  repo_url: https://github.com/kolega-ai/kolega-code
+  docs_url: https://kolega-ai.github.io/kolega-code/
+  categories:
+    - coding-agents
+    - terminal-agents
+  primary_category: coding-agents
+  tags:
+    - agentic-coding
+    - coding
+    - open-source
+    - repo-editing
+    - terminal-agent
+  interfaces:
+    - cli
+  deployment: local
+  source_model: open-source
+  license: Apache-2.0
+  curation_status: draft
+  review_notes: "Draft: new submission awaiting review."
+  added: 2026-08-17
+  last_checked: 2026-08-17
+  sources:
+    - https://github.com/kolega-ai/kolega-code
+    - https://kolega-ai.github.io/kolega-code/
 - slug: komos
   name: Komos
   description: Hosted browser automation platform for reusable AI tasks that drive websites, call APIs, process files, and run operations workflows.

--- a/data/tools.yml
+++ b/data/tools.yml
@@ -4774,8 +4774,7 @@
   deployment: local
   source_model: open-source
   license: Apache-2.0
-  curation_status: draft
-  review_notes: "Draft: new submission awaiting review."
+  curation_status: reviewed
   added: 2026-08-17
   last_checked: 2026-08-17
   sources:

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -2,7 +2,7 @@
 
 # Full Comparison Matrix
 
-This is the complete comparison matrix for all 281 reviewed tools.
+This is the complete comparison matrix for all 282 reviewed tools.
 
 | Tool | Main shelf | OSS | Local | Self-hosted | CLI | IDE | MCP | Links |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -141,6 +141,7 @@ This is the complete comparison matrix for all 281 reviewed tools.
 | [Junie](https://www.jetbrains.com/junie/) | Coding agents | No | No | No | Yes | Yes | No | [Website](https://www.jetbrains.com/junie/) / [Docs](https://www.jetbrains.com/help/ai-assistant/junie-agent.html) / [Repo](https://github.com/JetBrains/junie) |
 | [Keywords AI](https://keywordsai.co) | Agent observability | No | No | No | No | No | No | [Website](https://keywordsai.co) / [Docs](https://docs.keywordsai.co) |
 | [KoboldCpp](https://koboldcpp.com) | Local LLM developer tools | Yes | Yes | Yes | Yes | No | No | [Website](https://koboldcpp.com) / [Docs](https://github.com/LostRuins/koboldcpp/wiki) / [Repo](https://github.com/LostRuins/koboldcpp) |
+| [Kolega Code](https://github.com/kolega-ai/kolega-code) | Coding agents | Yes | Yes | No | Yes | No | No | [Docs](https://kolega-ai.github.io/kolega-code/) / [Repo](https://github.com/kolega-ai/kolega-code) |
 | [Komos](https://www.komos.ai/browser-automation-tools) | Browser agents | No | No | No | No | No | No | [Website](https://www.komos.ai/browser-automation-tools) / [Docs](https://docs.komos.ai/) |
 | [LangChain OpenEvals](https://github.com/langchain-ai/openevals) | Agent evals | Yes | No | No | No | No | No | [Repo](https://github.com/langchain-ai/openevals) |
 | [LangFair](https://cvs-health.github.io/langfair/) | Agent evals | Yes | No | No | No | No | No | [Docs](https://cvs-health.github.io/langfair/) / [Repo](https://github.com/cvs-health/langfair) |


### PR DESCRIPTION
# Add Kolega Code to tools directory

Adds Kolega Code to `data/tools.yml` as a draft entry, following the contributing guidelines.

Entry fields: categories `coding-agents` and `terminal-agents` with primary category `coding-agents`, tags and interfaces matching existing coding-agent entries, license Apache-2.0, sources pointing at the official repo and docs.

Ran `npm run sort`, `npm run generate`, and `npm test`. All pass; the entry is queued under Needs review (draft count went from 84 to 85), ready for the maintainer to promote once the metadata is checked.
