### PR TITLE
[codex] add agent-watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">Window-shop coding agents, IDE assistants, MCP tooling, evals, observability, security, and self-hosted AI dev stacks.</p>
 
-<p align="center"><code>367 tools</code> <code>283 reviewed</code> <code>84 draft</code> <code>18 active reviewed shelves</code></p>
+<p align="center"><code>368 tools</code> <code>284 reviewed</code> <code>84 draft</code> <code>18 active reviewed shelves</code></p>
 
 ## Why this exists
 
@@ -70,7 +70,7 @@ No rankings. No launch hype. Just a clean storefront for discovering tools worth
 
 ### Build with agents
 
-[Coding agents](#coding-agents) (30) · [Terminal agents](#terminal-agents) (18) · [IDE assistants](#ide-assistants) (17) · [Browser agents](#browser-agents) (25)
+[Coding agents](#coding-agents) (30) · [Terminal agents](#terminal-agents) (19) · [IDE assistants](#ide-assistants) (17) · [Browser agents](#browser-agents) (25)
 
 ### Extend agents
 
@@ -78,7 +78,7 @@ No rankings. No launch hype. Just a clean storefront for discovering tools worth
 
 ### Operate agents
 
-[Agent observability](#agent-observability) (44) · [Agent evals](#agent-evals) (23)
+[Agent observability](#agent-observability) (45) · [Agent evals](#agent-evals) (23)
 
 ### Run locally/self-host
 
@@ -90,7 +90,7 @@ No rankings. No launch hype. Just a clean storefront for discovering tools worth
 
 ## Comparison Matrix
 
-_Showing a curated top 50 tools. See [docs/COMPARISON.md](docs/COMPARISON.md) for the full matrix of all 283 reviewed tools._
+_Showing a curated top 50 tools. See [docs/COMPARISON.md](docs/COMPARISON.md) for the full matrix of all 284 reviewed tools._
 
 | Tool | Main shelf | OSS | Local | Self-hosted | CLI | IDE | MCP | Links |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -192,6 +192,7 @@ AI developer tools primarily operated from a command-line interface.
 
 | Tool | Good for | Experience | Links |
 | --- | --- | --- | --- |
+| [agent-watch](https://github.com/soul-sol/agent-watch) | POSIX shell scripts that classify background coding-agent runs and distinguish transport failures from credential failures before launch. | CLI · Local | [Docs](https://github.com/soul-sol/agent-watch#readme) / [Repo](https://github.com/soul-sol/agent-watch) |
 | [agenttrace](https://luoyuctl.github.io/agenttrace/) | Local CLI/TUI that turns AI coding agent session logs into cost, token, latency, failure, and health reports. | CLI · Local | [Website](https://luoyuctl.github.io/agenttrace/) / [Docs](https://github.com/luoyuctl/agenttrace#readme) / [Repo](https://github.com/luoyuctl/agenttrace) |
 | [Aider](https://aider.chat/) | Open-source terminal pair programmer that edits tracked files in a local Git repository. | CLI · Local | [Website](https://aider.chat/) / [Docs](https://aider.chat/docs/) / [Repo](https://github.com/Aider-AI/aider) |
 | [Amazon Q Developer](https://aws.amazon.com/q/developer/) | AWS coding assistant with IDE, CLI, and GitHub agents for coding, testing, review, and transformations. | CLI · GitHub app · IDE · Hybrid | [Website](https://aws.amazon.com/q/developer/) / [Docs](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/what-is.html) |
@@ -373,6 +374,7 @@ Tools for tracing, monitoring, and debugging agent or LLM application behavior.
 | Tool | Good for | Experience | Links |
 | --- | --- | --- | --- |
 | [Agent Island](https://agent-island.dev) | Local desktop companion that shows quota, cost, and live session state for Claude Code, Codex, Antigravity, Grok, and Cursor in the macOS notch or Windows tray. | Desktop · Local | [Website](https://agent-island.dev) / [Repo](https://github.com/tristan666666/agent-island) |
+| [agent-watch](https://github.com/soul-sol/agent-watch) | POSIX shell scripts that classify background coding-agent runs and distinguish transport failures from credential failures before launch. | CLI · Local | [Docs](https://github.com/soul-sol/agent-watch#readme) / [Repo](https://github.com/soul-sol/agent-watch) |
 | [agenttrace](https://luoyuctl.github.io/agenttrace/) | Local CLI/TUI that turns AI coding agent session logs into cost, token, latency, failure, and health reports. | CLI · Local | [Website](https://luoyuctl.github.io/agenttrace/) / [Docs](https://github.com/luoyuctl/agenttrace#readme) / [Repo](https://github.com/luoyuctl/agenttrace) |
 | [Amazon CloudWatch GenAI Observability](https://aws.amazon.com/cloudwatch/) | CloudWatch capabilities for monitoring and tracing generative AI agents, workloads, and quality metrics on AWS. | API · Web · Hosted | [Website](https://aws.amazon.com/cloudwatch/) / [Docs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/GenAI-observability.html) / [Repo](https://github.com/aws-samples/sample-amazon-cloudwatch-generative-ai-observability) |
 | [Arize AX](https://arize.com/ai-agents/agent-observability/) | Commercial agent and LLM observability platform built on Phoenix for tracing, evaluation, and monitoring production AI systems. | API · Web · Hosted | [Website](https://arize.com/ai-agents/agent-observability/) / [Docs](https://arize.com/docs/ax/observe/quickstart-llm) |
@@ -634,6 +636,7 @@ Directories, curated lists, and registries of AI developer tools and resources.
 
 ## New Arrivals
 
+- 2026-09-04: [agent-watch](https://github.com/soul-sol/agent-watch)
 - 2026-08-28: [SandBase CLI](https://github.com/sandbaseai/cli)
 - 2026-08-17: [Kolega Code](https://github.com/kolega-ai/kolega-code)
 - 2026-08-16: [Agent QA](https://vostride.com/docs/agent-qa)
@@ -641,7 +644,6 @@ Directories, curated lists, and registries of AI developer tools and resources.
 - 2026-07-27: [cursor-bridge](https://github.com/hkc5/cursor-bridge)
 - 2026-07-24: [whatbroke](https://github.com/arthi-arumugam-git/whatbroke)
 - 2026-07-22: [UIZZE](https://uizze.com)
-- 2026-07-16: [Agent Island](https://agent-island.dev)
 
 ## Needs review
 

--- a/data/tools.yml
+++ b/data/tools.yml
@@ -265,6 +265,36 @@
   sources:
     - https://awesome.ecosyste.ms/projects/github.com%2FEmergenceAI%2FAgent-E
     - https://github.com/EmergenceAI/Agent-E
+- slug: agent-watch
+  name: agent-watch
+  description: POSIX shell scripts that classify background coding-agent runs and distinguish transport failures from credential failures before launch.
+  website_url: https://github.com/soul-sol/agent-watch
+  repo_url: https://github.com/soul-sol/agent-watch
+  docs_url: https://github.com/soul-sol/agent-watch#readme
+  categories:
+    - agent-observability
+    - terminal-agents
+  primary_category: agent-observability
+  tags:
+    - cli
+    - debugging
+    - local-first
+    - monitoring
+    - observability
+    - open-source
+    - terminal
+  interfaces:
+    - cli
+  deployment: local
+  source_model: open-source
+  license: MIT
+  curation_status: reviewed
+  added: 2026-09-04
+  last_checked: 2026-09-04
+  sources:
+    - https://github.com/soul-sol/agent-watch
+    - https://github.com/soul-sol/agent-watch/releases/tag/v0.2.0
+    - https://github.com/soul-sol/agent-watch/releases/tag/v0.3.0
 - slug: agent-webvoyager
   name: Agent-WebVoyager
   description: Implementation showcasing an autonomous WebVoyager-style agent that navigates and extracts data from sites via visual interactions.

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -2,7 +2,7 @@
 
 # Full Comparison Matrix
 
-This is the complete comparison matrix for all 283 reviewed tools.
+This is the complete comparison matrix for all 284 reviewed tools.
 
 | Tool | Main shelf | OSS | Local | Self-hosted | CLI | IDE | MCP | Links |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -14,6 +14,7 @@ This is the complete comparison matrix for all 283 reviewed tools.
 | [Agent Skills](https://github.com/datalayer/agent-skills) | Agent skill packs | Yes | Yes | No | No | No | Yes | [Repo](https://github.com/datalayer/agent-skills) |
 | [Agent Skills Specification](https://github.com/agentskills/agentskills) | Agent skill packs | Yes | No | No | No | No | No | [Repo](https://github.com/agentskills/agentskills) |
 | [Agent-E](https://github.com/EmergenceAI/Agent-E) | Browser agents | Yes | No | No | No | No | No | [Repo](https://github.com/EmergenceAI/Agent-E) |
+| [agent-watch](https://github.com/soul-sol/agent-watch) | Agent observability | Yes | Yes | No | Yes | No | No | [Docs](https://github.com/soul-sol/agent-watch#readme) / [Repo](https://github.com/soul-sol/agent-watch) |
 | [Agent-WebVoyager](https://github.com/mrmoxon/Agent-WebVoyager) | Browser agents | Yes | No | No | No | No | No | [Repo](https://github.com/mrmoxon/Agent-WebVoyager) |
 | [Agentic Security](https://github.com/msoedov/agentic_security) | Agent evals | Yes | Yes | No | Yes | No | No | [Repo](https://github.com/msoedov/agentic_security) |
 | [AgentSkills MCP](https://github.com/zouyingcao/agentskills-mcp) | Agent skill packs | Yes | Yes | No | No | No | Yes | [Repo](https://github.com/zouyingcao/agentskills-mcp) |


### PR DESCRIPTION
## Summary

- Add agent-watch as reviewed metadata under Agent observability, with Terminal agents as a secondary category.
- Regenerate README.md and docs/COMPARISON.md from data/tools.yml.

## Problem and effect

Developers running coding agents in background terminals need to tell active, completed, failed, and stalled runs apart. Without an entry for this local CLI-oriented tool, the observability and terminal shelves omit that specific workflow.

## Root cause and fix

Process liveness, terminal output, and transport/authentication failures are different signals. agent-watch handles those signals with POSIX-shell scripts. The metadata includes only fields confirmed from the repository, releases, and MIT license file.

## Data sources

- [x] Official sources used for new or changed tool metadata.
- [x] Uncertain metadata marked conservatively.
- [x] Description is factual and neutral.

Sources:
- https://github.com/soul-sol/agent-watch
- https://github.com/soul-sol/agent-watch/releases/tag/v0.2.0
- https://github.com/soul-sol/agent-watch/releases/tag/v0.3.0

## Checks

- [x] npm run sort
- [x] npm run generate
- [x] npm test

All 59 unit tests and catalog validation pass. The generated files place agent-watch alphabetically between Agent-E and Agent-WebVoyager.