### PR TITLE
Add Gateway From Scratch to self-hosted-ai-dev-stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">Window-shop coding agents, IDE assistants, MCP tooling, evals, observability, security, and self-hosted AI dev stacks.</p>
 
-<p align="center"><code>368 tools</code> <code>284 reviewed</code> <code>84 draft</code> <code>18 active reviewed shelves</code></p>
+<p align="center"><code>369 tools</code> <code>285 reviewed</code> <code>84 draft</code> <code>18 active reviewed shelves</code></p>
 
 ## Why this exists
 
@@ -82,7 +82,7 @@ No rankings. No launch hype. Just a clean storefront for discovering tools worth
 
 ### Run locally/self-host
 
-[Self-hosted AI dev stacks](#self-hosted-ai-dev-stacks) (25) · [Local LLM developer tools](#local-llm-developer-tools) (31)
+[Self-hosted AI dev stacks](#self-hosted-ai-dev-stacks) (26) · [Local LLM developer tools](#local-llm-developer-tools) (31)
 
 ### Automate repo work
 
@@ -90,7 +90,7 @@ No rankings. No launch hype. Just a clean storefront for discovering tools worth
 
 ## Comparison Matrix
 
-_Showing a curated top 50 tools. See [docs/COMPARISON.md](docs/COMPARISON.md) for the full matrix of all 284 reviewed tools._
+_Showing a curated top 50 tools. See [docs/COMPARISON.md](docs/COMPARISON.md) for the full matrix of all 285 reviewed tools._
 
 | Tool | Main shelf | OSS | Local | Self-hosted | CLI | IDE | MCP | Links |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -460,6 +460,7 @@ Self-hostable platforms and infrastructure for AI developer workflows.
 | [Clawix AI Platform](https://github.com/ClawixAI/clawix#readme) | Open-source, self-hosted multi-agent AI orchestration platform running agents in isolated Docker containers. | CLI · Web · Self-hosted | [Docs](https://github.com/ClawixAI/clawix#readme) / [Repo](https://github.com/ClawixAI/clawix) |
 | [DevBox AI Dev Stack](https://github.com/gl0bal01/devbox#readme) | Zero-trust dev environment repository including an AI dev stack installer for Docker-based tools on a VPS. | CLI · Self-hosted | [Docs](https://github.com/gl0bal01/devbox#readme) / [Repo](https://github.com/gl0bal01/devbox) |
 | [Dify](https://dify.ai) | Open-source LLMOps platform with visual studio for chatbots, workflows, agents, and RAG that supports self-hosted deployment. | API · Web · Hybrid | [Website](https://dify.ai) / [Docs](https://docs.dify.ai) / [Repo](https://github.com/langgenius/dify) |
+| [Gateway From Scratch](https://github.com/yingsuan-ai/gateway-from-scratch) | A minimal OpenAI-compatible API gateway teaching scaffold with multi-provider fallback, written in Node.js for learning gateway internals. | API · Template · Self-hosted | [Docs](https://github.com/yingsuan-ai/gateway-from-scratch/blob/main/docs/architecture.md) / [Repo](https://github.com/yingsuan-ai/gateway-from-scratch) |
 | [Harbor CLI Stack](https://github.com/harbor-ai/harbor#readme) | CLI tool that spins up a local LLM stack (Ollama, Open WebUI, others) with a single command using container orchestration. | CLI · Template · Local | [Docs](https://github.com/harbor-ai/harbor#readme) / [Repo](https://github.com/harbor-ai/harbor) |
 | [Jan Server](https://jan.ai) | Self-hosted agentic AI platform powered by local models with Docker Compose-based infrastructure files. | API · CLI · Framework · Web · Self-hosted | [Website](https://jan.ai) / [Docs](https://github.com/janhq/server#readme) / [Repo](https://github.com/janhq/server) |
 | [Langfuse](https://langfuse.com/docs) | Open-source LLM engineering platform for observability, tracing, prompt management, datasets, and evaluations. | API · Web · Hybrid | [Docs](https://langfuse.com/docs) / [Repo](https://github.com/langfuse/langfuse) |
@@ -636,6 +637,7 @@ Directories, curated lists, and registries of AI developer tools and resources.
 
 ## New Arrivals
 
+- 2026-09-05: [Gateway From Scratch](https://github.com/yingsuan-ai/gateway-from-scratch)
 - 2026-09-04: [agent-watch](https://github.com/soul-sol/agent-watch)
 - 2026-08-28: [SandBase CLI](https://github.com/sandbaseai/cli)
 - 2026-08-17: [Kolega Code](https://github.com/kolega-ai/kolega-code)
@@ -643,7 +645,6 @@ Directories, curated lists, and registries of AI developer tools and resources.
 - 2026-08-13: [Atomic Agent](https://atomicagent.io)
 - 2026-07-27: [cursor-bridge](https://github.com/hkc5/cursor-bridge)
 - 2026-07-24: [whatbroke](https://github.com/arthi-arumugam-git/whatbroke)
-- 2026-07-22: [UIZZE](https://uizze.com)
 
 ## Needs review
 

--- a/README.md
+++ b/README.md
@@ -647,7 +647,6 @@ Directories, curated lists, and registries of AI developer tools and resources.
 - 2026-08-16: [Agent QA](https://vostride.com/docs/agent-qa)
 - 2026-08-13: [Atomic Agent](https://atomicagent.io)
 - 2026-07-27: [cursor-bridge](https://github.com/hkc5/cursor-bridge)
-- 2026-07-24: [whatbroke](https://github.com/arthi-arumugam-git/whatbroke)
 
 ## Needs review
 

--- a/data/tools.yml
+++ b/data/tools.yml
@@ -3671,6 +3671,32 @@
     - https://galileo.ai
     - https://galileo.ai/blog/best-llm-observability-tools-compared-for-2024
     - https://galileo.ai/blog/llm-monitoring-vs-observability-understanding-the-key-differences
+- slug: gateway-from-scratch
+  name: Gateway From Scratch
+  description: A minimal OpenAI-compatible API gateway teaching scaffold with multi-provider fallback, written in Node.js for learning gateway internals.
+  website_url: https://github.com/yingsuan-ai/gateway-from-scratch
+  repo_url: https://github.com/yingsuan-ai/gateway-from-scratch
+  docs_url: https://github.com/yingsuan-ai/gateway-from-scratch/blob/main/docs/architecture.md
+  categories:
+    - self-hosted-ai-dev-stacks
+  tags:
+    - api
+    - gateway
+    - open-source
+    - openai-compatible
+    - proxy
+    - self-hosted
+  interfaces:
+    - api
+    - template
+  deployment: self-hosted
+  source_model: open-source
+  license: MIT
+  curation_status: reviewed
+  added: 2026-09-05
+  last_checked: 2026-09-05
+  sources:
+    - https://github.com/yingsuan-ai/gateway-from-scratch
 - slug: gemini-cli
   name: Gemini CLI
   description: Open-source terminal coding agent that uses tool calls and MCP servers to work on repository tasks.

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -2,7 +2,7 @@
 
 # Full Comparison Matrix
 
-This is the complete comparison matrix for all 284 reviewed tools.
+This is the complete comparison matrix for all 285 reviewed tools.
 
 | Tool | Main shelf | OSS | Local | Self-hosted | CLI | IDE | MCP | Links |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -111,6 +111,7 @@ This is the complete comparison matrix for all 284 reviewed tools.
 | [Firecrawl Web Agent](https://github.com/firecrawl/web-agent) | Browser agents | Yes | No | No | No | No | No | [Repo](https://github.com/firecrawl/web-agent) |
 | [Flexible GraphRAG Observability Stack](https://github.com/stevereiner/flexible-graphrag) | Agent observability | Yes | No | Yes | Yes | No | No | [Docs](https://github.com/stevereiner/flexible-graphrag/blob/main/docs/DEVELOPER/OBSERVABILITY/OBSERVABILITY.md) / [Repo](https://github.com/stevereiner/flexible-graphrag) |
 | [Galileo AI](https://galileo.ai) | Agent observability | No | No | No | No | No | No | [Website](https://galileo.ai) / [Docs](https://docs.galileo.ai) |
+| [Gateway From Scratch](https://github.com/yingsuan-ai/gateway-from-scratch) | Self-hosted AI dev stacks | Yes | No | Yes | No | No | No | [Docs](https://github.com/yingsuan-ai/gateway-from-scratch/blob/main/docs/architecture.md) / [Repo](https://github.com/yingsuan-ai/gateway-from-scratch) |
 | [Gemini CLI](https://developers.google.com/gemini-code-assist/docs/gemini-cli) | Coding agents | Yes | Yes | No | Yes | No | Yes | [Docs](https://developers.google.com/gemini-code-assist/docs/gemini-cli) / [Repo](https://github.com/google-gemini/gemini-cli) |
 | [Gemini Code Assist](https://developers.google.com/gemini-code-assist) | Coding agents | No | No | No | No | Yes | No | [Website](https://developers.google.com/gemini-code-assist) / [Docs](https://developers.google.com/gemini-code-assist/docs/overview) |
 | [GitBook AI (Assistant & Agent)](https://www.gitbook.com) | Documentation agents | No | No | No | No | No | Yes | [Website](https://www.gitbook.com) / [Docs](https://gitbook.com/docs) |


### PR DESCRIPTION
Add [Gateway From Scratch](https://github.com/yingsuan-ai/gateway-from-scratch), a minimal OpenAI-compatible API gateway teaching scaffold with multi-provider fallback, written in Node.js. It is MIT licensed and intended for learning gateway internals (request normalization, provider routing, fallback). Fits the `self-hosted-ai-dev-stacks` category.

- `data/tools.yml`: added `gateway-from-scratch` entry (category `self-hosted-ai-dev-stacks`; tags api / gateway / openai-compatible / open-source / proxy / self-hosted; interfaces api / template; deployment self-hosted; source_model open-source; license MIT; curation_status reviewed)
- `README.md` and `docs/COMPARISON.md` regenerated via `npm run generate`
- `npm test` passes (59/59 unit tests, validate clean)

All metadata uses official repository URLs and neutral, factual descriptions per CONTRIBUTING.md.